### PR TITLE
Fix websocket issue

### DIFF
--- a/app/gradleScript/dependencies.gradle
+++ b/app/gradleScript/dependencies.gradle
@@ -8,7 +8,7 @@ allprojects {
 
 ext {
     /* Version */
-    omisego = '1.1.2-alpha4'
+    omisego = '1.2.0-alpha1'
     supportLibrary = '1.0.0-rc02'
     kotlin = '1.2.61'
     retrofit = '2.4.0'

--- a/app/src/androidTest/java/network/omisego/omgwallet/BalanceDetailTest.kt
+++ b/app/src/androidTest/java/network/omisego/omgwallet/BalanceDetailTest.kt
@@ -40,7 +40,7 @@ class BalanceDetailTest : BaseInstrumentalTest() {
         @BeforeClass
         @JvmStatic
         fun setupClass() {
-            ClientProvider.init(LocalClientSetup())
+            ClientProvider.initHTTPClient(LocalClientSetup())
             Storage.clearSession()
             val response = ClientProvider.client.login(LoginParams(TestData.USER_EMAIL, TestData.USER_PASSWORD)).execute()
             Storage.saveUser(response.body()!!.data.user)

--- a/app/src/androidTest/java/network/omisego/omgwallet/ConsumeTransactionRequestTest.kt
+++ b/app/src/androidTest/java/network/omisego/omgwallet/ConsumeTransactionRequestTest.kt
@@ -44,7 +44,7 @@ class ConsumeTransactionRequestTest : BaseInstrumentalTest() {
         @BeforeClass
         @JvmStatic
         fun setupClass() {
-            ClientProvider.init(LocalClientSetup())
+            ClientProvider.initHTTPClient(LocalClientSetup())
             Storage.clearSession()
             val response = ClientProvider.client.login(LoginParams(TestData.USER_EMAIL, TestData.USER_PASSWORD)).execute()
             Storage.saveUser(response.body()!!.data.user)

--- a/app/src/androidTest/java/network/omisego/omgwallet/MainTest.kt
+++ b/app/src/androidTest/java/network/omisego/omgwallet/MainTest.kt
@@ -38,7 +38,7 @@ class MainTest : BaseInstrumentalTest() {
         @BeforeClass
         @JvmStatic
         fun setupClass() {
-            ClientProvider.init(LocalClientSetup())
+            ClientProvider.initHTTPClient(LocalClientSetup())
             Storage.clearSession()
             val response = ClientProvider.client.login(LoginParams(TestData.USER_EMAIL, TestData.USER_PASSWORD)).execute()
             Storage.saveUser(response.body()!!.data.user)

--- a/app/src/androidTest/java/network/omisego/omgwallet/PrefetchTest.kt
+++ b/app/src/androidTest/java/network/omisego/omgwallet/PrefetchTest.kt
@@ -34,7 +34,7 @@ class PrefetchTest : BaseInstrumentalTest() {
         @JvmStatic
         fun setupClass() {
             Storage.clearSession()
-            ClientProvider.init(LocalClientSetup())
+            ClientProvider.initHTTPClient(LocalClientSetup())
             val response = ClientProvider.client.login(LoginParams(TestData.USER_EMAIL, TestData.USER_PASSWORD)).execute()
             Storage.saveUser(response.body()!!.data.user)
             Storage.saveCredential(Credential(response.body()!!.data.authenticationToken))

--- a/app/src/androidTest/java/network/omisego/omgwallet/ProfileTest.kt
+++ b/app/src/androidTest/java/network/omisego/omgwallet/ProfileTest.kt
@@ -39,7 +39,7 @@ class ProfileTest : BaseInstrumentalTest() {
         @BeforeClass
         @JvmStatic
         fun setupClass() {
-            ClientProvider.init(LocalClientSetup())
+            ClientProvider.initHTTPClient(LocalClientSetup())
             Storage.clearSession()
             val response = ClientProvider.client.login(LoginParams(TestData.USER_EMAIL, TestData.USER_PASSWORD)).execute()
             Storage.saveUser(response.body()!!.data.user)

--- a/app/src/androidTest/java/network/omisego/omgwallet/QRTest.kt
+++ b/app/src/androidTest/java/network/omisego/omgwallet/QRTest.kt
@@ -30,7 +30,7 @@ class QRTest : BaseInstrumentalTest() {
 
     @Before
     fun setup() {
-        ClientProvider.init(LocalClientSetup())
+        ClientProvider.initHTTPClient(LocalClientSetup())
         Storage.clearSession()
         val response = ClientProvider.client.login(LoginParams(TestData.USER_EMAIL, TestData.USER_PASSWORD)).execute()
         Storage.saveWallets(MockData.walletList)

--- a/app/src/androidTest/java/network/omisego/omgwallet/base/BaseInstrumentalTest.kt
+++ b/app/src/androidTest/java/network/omisego/omgwallet/base/BaseInstrumentalTest.kt
@@ -87,7 +87,7 @@ open class BaseInstrumentalTest {
     }
 
     fun setupClientProvider() {
-        ClientProvider.init(LocalClientSetup())
+        ClientProvider.initHTTPClient(LocalClientSetup())
     }
 
     fun start() {

--- a/app/src/main/java/network/omisego/omgwallet/AndroidViewModelFactory.kt
+++ b/app/src/main/java/network/omisego/omgwallet/AndroidViewModelFactory.kt
@@ -11,8 +11,6 @@ import android.app.Application
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import co.omisego.omisego.qrcode.generator.QRGenerator
-import network.omisego.omgwallet.data.LocalRepository
-import network.omisego.omgwallet.data.RemoteRepository
 import network.omisego.omgwallet.screen.auth.balance.detail.BalanceDetailItemViewModel
 import network.omisego.omgwallet.screen.auth.balance.detail.BalanceDetailViewModel
 import network.omisego.omgwallet.screen.auth.confirm.ConfirmTransactionRequestViewModel
@@ -24,37 +22,38 @@ import network.omisego.omgwallet.screen.auth.splash.PreloadResourceViewModel
 import network.omisego.omgwallet.screen.unauth.signin.FingerprintBottomSheetViewModel
 import network.omisego.omgwallet.screen.unauth.signin.SignInViewModel
 import network.omisego.omgwallet.util.BiometricUtil
+import network.omisego.omgwallet.util.RepositoryUtil
 
 @Suppress("UNCHECKED_CAST")
 class AndroidViewModelFactory(private val application: Application) : ViewModelProvider.AndroidViewModelFactory(application) {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
         return when {
             modelClass.isAssignableFrom(SignInViewModel::class.java) -> {
-                return SignInViewModel(application, LocalRepository(), RemoteRepository(), BiometricUtil()) as T
+                return SignInViewModel(application, RepositoryUtil.localRepository, RepositoryUtil.remoteRepository, BiometricUtil()) as T
             }
             modelClass.isAssignableFrom(FingerprintBottomSheetViewModel::class.java) -> {
                 FingerprintBottomSheetViewModel(application) as T
             }
             modelClass.isAssignableFrom(ProfileViewModel::class.java) -> {
-                return ProfileViewModel(application, LocalRepository(), RemoteRepository()) as T
+                return ProfileViewModel(application, RepositoryUtil.localRepository) as T
             }
             modelClass.isAssignableFrom(TransactionListViewModel::class.java) -> {
-                return TransactionListViewModel(application, LocalRepository(), RemoteRepository(), TransactionListTransformer(application)) as T
+                return TransactionListViewModel(application, RepositoryUtil.localRepository, RepositoryUtil.remoteRepository, TransactionListTransformer(application)) as T
             }
             modelClass.isAssignableFrom(ShowQRViewModel::class.java) -> {
-                return ShowQRViewModel(application, LocalRepository(), QRGenerator()) as T
+                return ShowQRViewModel(application, RepositoryUtil.localRepository, QRGenerator()) as T
             }
             modelClass.isAssignableFrom(BalanceDetailItemViewModel::class.java) -> {
                 return BalanceDetailItemViewModel(application) as T
             }
             modelClass.isAssignableFrom(BalanceDetailViewModel::class.java) -> {
-                return BalanceDetailViewModel(application, LocalRepository()) as T
+                return BalanceDetailViewModel(application, RepositoryUtil.localRepository) as T
             }
             modelClass.isAssignableFrom(PreloadResourceViewModel::class.java) -> {
-                return PreloadResourceViewModel(application, LocalRepository(), RemoteRepository()) as T
+                return PreloadResourceViewModel(application, RepositoryUtil.localRepository, RepositoryUtil.remoteRepository) as T
             }
             modelClass.isAssignableFrom(ConfirmTransactionRequestViewModel::class.java) -> {
-                return ConfirmTransactionRequestViewModel(application, LocalRepository(), RemoteRepository()) as T
+                return ConfirmTransactionRequestViewModel(application, RepositoryUtil.localRepository, RepositoryUtil.remoteRepository) as T
             }
             else -> {
                 throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")

--- a/app/src/main/java/network/omisego/omgwallet/GlobalViewModel.kt
+++ b/app/src/main/java/network/omisego/omgwallet/GlobalViewModel.kt
@@ -1,0 +1,39 @@
+package network.omisego.omgwallet
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import co.omisego.omisego.model.APIError
+import co.omisego.omisego.model.TransactionConsumption
+import co.omisego.omisego.websocket.SocketClientContract
+import network.omisego.omgwallet.data.RemoteRepository
+import network.omisego.omgwallet.extension.logi
+
+/*
+ * OmiseGO
+ *
+ * Created by Phuchit Sirimongkolsathien on 23/11/2018 AD.
+ * Copyright © 2017-2018 OmiseGO. All rights reserved.
+ */
+
+class GlobalViewModel(val remoteRepository: RemoteRepository) : ViewModel() {
+    val liveConsumptionRequestEvent: MutableLiveData<TransactionConsumption> by lazy { MutableLiveData<TransactionConsumption>() }
+    val liveConsumptionRequestFailEvent: MutableLiveData<APIError> by lazy { MutableLiveData<APIError>() }
+    val liveConsumptionFinalizedEvent: MutableLiveData<TransactionConsumption> by lazy { MutableLiveData<TransactionConsumption>() }
+    val liveConsumptionFinalizedFailEvent: MutableLiveData<APIError> by lazy { MutableLiveData<APIError>() }
+    val liveAuthenticationToken: MutableLiveData<String> by lazy { MutableLiveData<String>() }
+
+    fun startListenForUserEvent(socketClient: SocketClientContract.Client) {
+        logi("start listen for user event...")
+        remoteRepository.listenUserSocketEvent(
+            socketClient,
+            liveConsumptionRequestEvent,
+            liveConsumptionRequestFailEvent,
+            liveConsumptionFinalizedEvent,
+            liveConsumptionFinalizedFailEvent
+        )
+    }
+
+    fun stopListenForUserEvent(socketClient: SocketClientContract.Client) {
+        remoteRepository.stopListeningToUserSocketEvent(socketClient)
+    }
+}

--- a/app/src/main/java/network/omisego/omgwallet/MainActivity.kt
+++ b/app/src/main/java/network/omisego/omgwallet/MainActivity.kt
@@ -2,14 +2,51 @@ package network.omisego.omgwallet
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Observer
 import androidx.navigation.findNavController
+import co.omisego.omisego.model.ClientAuthenticationToken
+import network.omisego.omgwallet.extension.provideViewModel
+import network.omisego.omgwallet.model.Credential
+import network.omisego.omgwallet.network.ClientProvider
+import network.omisego.omgwallet.util.RepositoryUtil
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : AppCompatActivity(), LoginListener {
+
+    private lateinit var globalViewModel: GlobalViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setTheme(R.style.OMGTheme)
         setContentView(R.layout.activity_main)
+        globalViewModel = provideViewModel()
+        observeEvent()
+    }
+
+    private fun observeEvent() {
+        globalViewModel.liveAuthenticationToken.observe(this, Observer { authenticationToken ->
+            if (authenticationToken == null) {
+                globalViewModel.stopListenForUserEvent(ClientProvider.socketClient!!)
+                RepositoryUtil.localRepository.clearSession()
+                ClientProvider.socketClient = null
+            } else {
+                ClientProvider.initSocketClient(authenticationToken)
+                globalViewModel.startListenForUserEvent(ClientProvider.socketClient!!)
+            }
+        })
+    }
+
+    override fun onStart() {
+        super.onStart()
+        ClientProvider.socketClient?.let {
+            globalViewModel.startListenForUserEvent(it)
+        }
+    }
+
+    override fun onStop() {
+        ClientProvider.socketClient?.let {
+            globalViewModel.stopListenForUserEvent(it)
+        }
+        super.onStop()
     }
 
     override fun onSupportNavigateUp() = findNavController(R.id.nav_host).navigateUp()
@@ -19,4 +56,22 @@ class MainActivity : AppCompatActivity() {
             super.onBackPressed()
         }
     }
+
+    override fun onLoggedin(email: String, token: ClientAuthenticationToken) {
+        val credential = Credential(token.authenticationToken)
+        RepositoryUtil.localRepository.clearOldAccountCache(email)
+        RepositoryUtil.localRepository.saveUserEmail(email)
+        RepositoryUtil.localRepository.saveUser(token.user)
+        RepositoryUtil.localRepository.saveCredential(credential)
+        globalViewModel.liveAuthenticationToken.value = credential.authenticationToken
+    }
+
+    override fun onLoggedout() {
+        globalViewModel.liveAuthenticationToken.value = null
+    }
+}
+
+interface LoginListener {
+    fun onLoggedin(email: String, token: ClientAuthenticationToken)
+    fun onLoggedout()
 }

--- a/app/src/main/java/network/omisego/omgwallet/OMGWalletApp.kt
+++ b/app/src/main/java/network/omisego/omgwallet/OMGWalletApp.kt
@@ -8,17 +8,15 @@ package network.omisego.omgwallet
  */
 
 import android.app.Application
-import co.omisego.omisego.model.ClientAuthenticationToken
 import com.facebook.stetho.Stetho
 import network.omisego.omgwallet.data.LocalRepository
 import network.omisego.omgwallet.data.RemoteRepository
-import network.omisego.omgwallet.model.Credential
 import network.omisego.omgwallet.network.ClientProvider
 import network.omisego.omgwallet.network.ProductionClientSetup
 import network.omisego.omgwallet.util.ContextUtil
 import network.omisego.omgwallet.util.RepositoryUtil
 
-class OMGWalletApp : Application(), LoginListener {
+class OMGWalletApp : Application() {
     override fun onCreate() {
         super.onCreate()
         ContextUtil.context = applicationContext
@@ -30,23 +28,4 @@ class OMGWalletApp : Application(), LoginListener {
         }
         Stetho.initializeWithDefaults(this)
     }
-
-    override fun onLoggedin(email: String, token: ClientAuthenticationToken) {
-        val credential = Credential(token.authenticationToken)
-        RepositoryUtil.localRepository.clearOldAccountCache(email)
-        RepositoryUtil.localRepository.saveUserEmail(email)
-        RepositoryUtil.localRepository.saveUser(token.user)
-        RepositoryUtil.localRepository.saveCredential(credential)
-        ClientProvider.initSocketClient(credential.authenticationToken!!)
-    }
-
-    override fun onLoggedout() {
-        RepositoryUtil.remoteRepository.stopListeningToUserSocketEvent()
-        RepositoryUtil.localRepository.clearSession()
-    }
-}
-
-interface LoginListener {
-    fun onLoggedin(email: String, token: ClientAuthenticationToken)
-    fun onLoggedout()
 }

--- a/app/src/main/java/network/omisego/omgwallet/OMGWalletApp.kt
+++ b/app/src/main/java/network/omisego/omgwallet/OMGWalletApp.kt
@@ -8,17 +8,45 @@ package network.omisego.omgwallet
  */
 
 import android.app.Application
+import co.omisego.omisego.model.ClientAuthenticationToken
 import com.facebook.stetho.Stetho
+import network.omisego.omgwallet.data.LocalRepository
+import network.omisego.omgwallet.data.RemoteRepository
+import network.omisego.omgwallet.model.Credential
 import network.omisego.omgwallet.network.ClientProvider
 import network.omisego.omgwallet.network.ProductionClientSetup
 import network.omisego.omgwallet.util.ContextUtil
+import network.omisego.omgwallet.util.RepositoryUtil
 
-class OMGWalletApp : Application() {
-
+class OMGWalletApp : Application(), LoginListener {
     override fun onCreate() {
         super.onCreate()
         ContextUtil.context = applicationContext
-        ClientProvider.init(ProductionClientSetup())
+        RepositoryUtil.localRepository = LocalRepository()
+        RepositoryUtil.remoteRepository = RemoteRepository()
+        ClientProvider.initHTTPClient(ProductionClientSetup())
+        RepositoryUtil.localRepository.loadCredential().authenticationToken?.let {
+            ClientProvider.initSocketClient(it)
+        }
         Stetho.initializeWithDefaults(this)
     }
+
+    override fun onLoggedin(email: String, token: ClientAuthenticationToken) {
+        val credential = Credential(token.authenticationToken)
+        RepositoryUtil.localRepository.clearOldAccountCache(email)
+        RepositoryUtil.localRepository.saveUserEmail(email)
+        RepositoryUtil.localRepository.saveUser(token.user)
+        RepositoryUtil.localRepository.saveCredential(credential)
+        ClientProvider.initSocketClient(credential.authenticationToken!!)
+    }
+
+    override fun onLoggedout() {
+        RepositoryUtil.remoteRepository.stopListeningToUserSocketEvent()
+        RepositoryUtil.localRepository.clearSession()
+    }
+}
+
+interface LoginListener {
+    fun onLoggedin(email: String, token: ClientAuthenticationToken)
+    fun onLoggedout()
 }

--- a/app/src/main/java/network/omisego/omgwallet/ViewModelFactory.kt
+++ b/app/src/main/java/network/omisego/omgwallet/ViewModelFactory.kt
@@ -31,6 +31,9 @@ class ViewModelFactory : ViewModelProvider.NewInstanceFactory() {
             modelClass.isAssignableFrom(MainViewModel::class.java) -> {
                 return MainViewModel(RepositoryUtil.localRepository, RepositoryUtil.remoteRepository) as T
             }
+            modelClass.isAssignableFrom(GlobalViewModel::class.java) -> {
+                return GlobalViewModel(RepositoryUtil.remoteRepository) as T
+            }
             else -> {
                 throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
             }

--- a/app/src/main/java/network/omisego/omgwallet/ViewModelFactory.kt
+++ b/app/src/main/java/network/omisego/omgwallet/ViewModelFactory.kt
@@ -9,28 +9,27 @@ package network.omisego.omgwallet
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import network.omisego.omgwallet.data.LocalRepository
-import network.omisego.omgwallet.data.RemoteRepository
 import network.omisego.omgwallet.screen.auth.MainViewModel
 import network.omisego.omgwallet.screen.auth.balance.BalanceViewModel
 import network.omisego.omgwallet.screen.auth.profile.main.ConfirmFingerprintViewModel
 import network.omisego.omgwallet.screen.unauth.signup.SignupViewModel
+import network.omisego.omgwallet.util.RepositoryUtil
 
 @Suppress("UNCHECKED_CAST")
 class ViewModelFactory : ViewModelProvider.NewInstanceFactory() {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
         when {
             modelClass.isAssignableFrom(SignupViewModel::class.java) -> {
-                return SignupViewModel(RemoteRepository()) as T
+                return SignupViewModel(RepositoryUtil.remoteRepository) as T
             }
             modelClass.isAssignableFrom(BalanceViewModel::class.java) -> {
-                return BalanceViewModel(LocalRepository(), RemoteRepository()) as T
+                return BalanceViewModel(RepositoryUtil.localRepository, RepositoryUtil.remoteRepository) as T
             }
             modelClass.isAssignableFrom(ConfirmFingerprintViewModel::class.java) -> {
-                return ConfirmFingerprintViewModel(LocalRepository(), RemoteRepository()) as T
+                return ConfirmFingerprintViewModel(RepositoryUtil.localRepository, RepositoryUtil.remoteRepository) as T
             }
             modelClass.isAssignableFrom(MainViewModel::class.java) -> {
-                return MainViewModel(LocalRepository(), RemoteRepository()) as T
+                return MainViewModel(RepositoryUtil.localRepository, RepositoryUtil.remoteRepository) as T
             }
             else -> {
                 throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")

--- a/app/src/main/java/network/omisego/omgwallet/data/LocalRepository.kt
+++ b/app/src/main/java/network/omisego/omgwallet/data/LocalRepository.kt
@@ -2,9 +2,9 @@ package network.omisego.omgwallet.data
 
 import androidx.lifecycle.MutableLiveData
 import co.omisego.omisego.model.Token
+import co.omisego.omisego.model.TransactionRequestType
 import co.omisego.omisego.model.User
 import co.omisego.omisego.model.WalletList
-import co.omisego.omisego.model.transaction.request.TransactionRequestType
 import network.omisego.omgwallet.data.contract.BalanceDataRepository
 import network.omisego.omgwallet.livedata.Event
 import network.omisego.omgwallet.model.APIResult
@@ -46,6 +46,8 @@ class LocalRepository : BalanceDataRepository {
     fun loadFingerprintCredential() = Storage.loadFingerprintCredential()
 
     fun loadTransactionRequestFormattedId() = Storage.loadFormattedId()
+
+    fun loadCredential() = Storage.loadCredential()
 
     fun loadUser() = Storage.loadUser()
 

--- a/app/src/main/java/network/omisego/omgwallet/data/RemoteRepository.kt
+++ b/app/src/main/java/network/omisego/omgwallet/data/RemoteRepository.kt
@@ -12,6 +12,7 @@ import co.omisego.omisego.model.params.TransactionConsumptionActionParams
 import co.omisego.omisego.model.params.TransactionListParams
 import co.omisego.omisego.model.params.client.TransactionRequestCreateParams
 import co.omisego.omisego.operation.startListeningEvents
+import co.omisego.omisego.websocket.SocketClientContract
 import co.omisego.omisego.websocket.event.TransactionConsumptionFinalizedEvent
 import co.omisego.omisego.websocket.event.TransactionConsumptionRequestEvent
 import co.omisego.omisego.websocket.listener.SocketCustomEventListener
@@ -66,6 +67,7 @@ class RemoteRepository : BalanceDataRepository {
     }
 
     fun listenUserSocketEvent(
+        socketClient: SocketClientContract.Client,
         liveConsumptionRequestEvent: MutableLiveData<TransactionConsumption>,
         liveConsumptionRequestFailEvent: MutableLiveData<APIError>,
         liveConsumptionFinalizedEvent: MutableLiveData<TransactionConsumption>,
@@ -75,7 +77,7 @@ class RemoteRepository : BalanceDataRepository {
         val user = Storage.loadUser()
         logi("load the user ${user?.email}")
         user?.startListeningEvents(
-            ClientProvider.socketClient,
+            socketClient,
             listener = SocketCustomEventListener.forEvent<TransactionConsumptionRequestEvent> {
                 // Show confirmation fragment here
                 val txConsumption = it.socketReceive
@@ -88,7 +90,7 @@ class RemoteRepository : BalanceDataRepository {
         logi("listening for consumption request event successfully.")
 
         user?.startListeningEvents(
-            ClientProvider.socketClient,
+            socketClient,
             listener = SocketCustomEventListener.forEvent<TransactionConsumptionFinalizedEvent> {
                 /* TODO: Handle transaction consumption finalized event here */
                 val txConsumption = it.socketReceive
@@ -101,8 +103,8 @@ class RemoteRepository : BalanceDataRepository {
         logi("listening for consumption finalized event successfully.")
     }
 
-    fun stopListeningToUserSocketEvent() {
+    fun stopListeningToUserSocketEvent(socketClient: SocketClientContract.Client) {
         val user = Storage.loadUser()
-        user?.stopListening(ClientProvider.socketClient)
+        user?.stopListening(socketClient)
     }
 }

--- a/app/src/main/java/network/omisego/omgwallet/data/RemoteRepository.kt
+++ b/app/src/main/java/network/omisego/omgwallet/data/RemoteRepository.kt
@@ -4,18 +4,19 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import co.omisego.omisego.model.APIError
 import co.omisego.omisego.model.OMGResponse
+import co.omisego.omisego.model.TransactionConsumption
+import co.omisego.omisego.model.TransactionRequest
 import co.omisego.omisego.model.params.LoginParams
 import co.omisego.omisego.model.params.SignUpParams
-import co.omisego.omisego.model.transaction.consumption.TransactionConsumption
-import co.omisego.omisego.model.transaction.consumption.TransactionConsumptionActionParams
-import co.omisego.omisego.model.transaction.list.TransactionListParams
-import co.omisego.omisego.model.transaction.request.TransactionRequest
-import co.omisego.omisego.model.transaction.request.TransactionRequestCreateParams
+import co.omisego.omisego.model.params.TransactionConsumptionActionParams
+import co.omisego.omisego.model.params.TransactionListParams
+import co.omisego.omisego.model.params.client.TransactionRequestCreateParams
 import co.omisego.omisego.operation.startListeningEvents
 import co.omisego.omisego.websocket.event.TransactionConsumptionFinalizedEvent
 import co.omisego.omisego.websocket.event.TransactionConsumptionRequestEvent
 import co.omisego.omisego.websocket.listener.SocketCustomEventListener
 import network.omisego.omgwallet.data.contract.BalanceDataRepository
+import network.omisego.omgwallet.extension.logi
 import network.omisego.omgwallet.extension.subscribe
 import network.omisego.omgwallet.extension.subscribeSingleEvent
 import network.omisego.omgwallet.livedata.Event
@@ -72,10 +73,10 @@ class RemoteRepository : BalanceDataRepository {
     ) {
         /* Listen for request event */
         val user = Storage.loadUser()
+        logi("load the user ${user?.email}")
         user?.startListeningEvents(
             ClientProvider.socketClient,
             listener = SocketCustomEventListener.forEvent<TransactionConsumptionRequestEvent> {
-                /* TODO: Handle incoming transaction consumption request event here*/
                 // Show confirmation fragment here
                 val txConsumption = it.socketReceive
                 if (txConsumption.error == null) {
@@ -84,6 +85,8 @@ class RemoteRepository : BalanceDataRepository {
                     liveConsumptionRequestFailEvent.value = txConsumption.error
                 }
             })
+        logi("listening for consumption request event successfully.")
+
         user?.startListeningEvents(
             ClientProvider.socketClient,
             listener = SocketCustomEventListener.forEvent<TransactionConsumptionFinalizedEvent> {
@@ -95,6 +98,7 @@ class RemoteRepository : BalanceDataRepository {
                     liveConsumptionFinalizedFailEvent.value = txConsumption.error
                 }
             })
+        logi("listening for consumption finalized event successfully.")
     }
 
     fun stopListeningToUserSocketEvent() {

--- a/app/src/main/java/network/omisego/omgwallet/databinding/TransactionBinding.kt
+++ b/app/src/main/java/network/omisego/omgwallet/databinding/TransactionBinding.kt
@@ -1,4 +1,4 @@
-package network.omisego.omgwallet.screen.auth.profile.transaction
+package network.omisego.omgwallet.databinding
 
 /*
  * OmiseGO
@@ -10,11 +10,11 @@ package network.omisego.omgwallet.screen.auth.profile.transaction
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.databinding.BindingAdapter
+import co.omisego.omisego.model.Transaction
 import co.omisego.omisego.model.pagination.Paginable
-import co.omisego.omisego.model.transaction.Transaction
 import network.omisego.omgwallet.R
 
-object TransactionBindingAdapter {
+object TransactionBinding {
     @JvmStatic
     @BindingAdapter("transaction")
     fun colorizedTransaction(tv: TextView, transaction: Transaction) {

--- a/app/src/main/java/network/omisego/omgwallet/extension/FragmentExt.kt
+++ b/app/src/main/java/network/omisego/omgwallet/extension/FragmentExt.kt
@@ -29,9 +29,9 @@ fun <T : ViewDataBinding> Fragment.bindingInflate(
 
 fun Fragment.findLoginListener(): LoginListener? {
     val app = activity
-    return if(app is LoginListener){
+    return if (app is LoginListener) {
         app
-    }else {
+    } else {
         null
     }
 }

--- a/app/src/main/java/network/omisego/omgwallet/extension/FragmentExt.kt
+++ b/app/src/main/java/network/omisego/omgwallet/extension/FragmentExt.kt
@@ -6,6 +6,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.Fragment
 import androidx.navigation.Navigation
+import network.omisego.omgwallet.LoginListener
 import network.omisego.omgwallet.MainActivity
 import network.omisego.omgwallet.R
 
@@ -25,5 +26,14 @@ fun <T : ViewDataBinding> Fragment.bindingInflate(
     container,
     false
 )
+
+fun Fragment.findLoginListener(): LoginListener? {
+    val app = activity?.application
+    return if(app is LoginListener){
+        app
+    }else {
+        null
+    }
+}
 
 fun Fragment.findRootNavController() = Navigation.findNavController(activity as MainActivity, R.id.nav_host)

--- a/app/src/main/java/network/omisego/omgwallet/extension/FragmentExt.kt
+++ b/app/src/main/java/network/omisego/omgwallet/extension/FragmentExt.kt
@@ -28,7 +28,7 @@ fun <T : ViewDataBinding> Fragment.bindingInflate(
 )
 
 fun Fragment.findLoginListener(): LoginListener? {
-    val app = activity?.application
+    val app = activity
     return if(app is LoginListener){
         app
     }else {

--- a/app/src/main/java/network/omisego/omgwallet/extension/PaginationTransactionExt.kt
+++ b/app/src/main/java/network/omisego/omgwallet/extension/PaginationTransactionExt.kt
@@ -7,8 +7,8 @@ package network.omisego.omgwallet.extension
  * Copyright © 2017-2018 OmiseGO. All rights reserved.
  */
 
+import co.omisego.omisego.model.Transaction
 import co.omisego.omisego.model.pagination.PaginationList
-import co.omisego.omisego.model.transaction.Transaction
 import network.omisego.omgwallet.state.TransactionListState
 
 val PaginationList<Transaction>.state: TransactionListState

--- a/app/src/main/java/network/omisego/omgwallet/model/APIResult.kt
+++ b/app/src/main/java/network/omisego/omgwallet/model/APIResult.kt
@@ -16,6 +16,7 @@ sealed class APIResult {
     fun <T> handle(handleSuccess: (T) -> Unit, handleError: (APIError) -> Unit) {
         when (this) {
             is Success<*> -> {
+                this.data ?: return
                 handleSuccess(this.data as T)
             }
             is Fail<*> -> {

--- a/app/src/main/java/network/omisego/omgwallet/network/ClientProvider.kt
+++ b/app/src/main/java/network/omisego/omgwallet/network/ClientProvider.kt
@@ -1,16 +1,11 @@
 package network.omisego.omgwallet.network
 
-import android.util.Log
 import co.omisego.omisego.OMGAPIClient
-import co.omisego.omisego.model.APIError
 import co.omisego.omisego.model.ClientConfiguration
 import co.omisego.omisego.network.ewallet.EWalletClient
 import co.omisego.omisego.websocket.OMGSocketClient
 import co.omisego.omisego.websocket.SocketClientContract
-import co.omisego.omisego.websocket.listener.SocketChannelListener
-import co.omisego.omisego.websocket.listener.SocketConnectionListener
 import com.facebook.stetho.okhttp3.StethoInterceptor
-import network.omisego.omgwallet.extension.logi
 import network.omisego.omgwallet.storage.Storage
 import okhttp3.logging.HttpLoggingInterceptor
 
@@ -45,36 +40,6 @@ object ClientProvider {
             authenticationToken = authenticationToken
         )
         socketClient = createSocketClient()
-        addSocketListener()
-    }
-
-    fun addSocketListener() {
-        ClientProvider.socketClient?.addChannelListener(object : SocketChannelListener {
-            override fun onError(apiError: APIError): Boolean {
-                logi("Error: ${apiError.description}")
-                return true
-            }
-
-            override fun onJoinedChannel(topic: String): Boolean {
-                Log.i("Socket", "Joined: ${topic}")
-                return true
-            }
-
-            override fun onLeftChannel(topic: String): Boolean {
-                Log.i("Socket", "Left $topic")
-                return true
-            }
-        })
-
-        ClientProvider.socketClient?.addConnectionListener(object : SocketConnectionListener {
-            override fun onConnected() {
-                Log.i("Socket", "Connected")
-            }
-
-            override fun onDisconnected(throwable: Throwable?) {
-                Log.i("Socket", "Disconnected")
-            }
-        })
     }
 
     private fun create(): OMGAPIClient {

--- a/app/src/main/java/network/omisego/omgwallet/network/ClientProvider.kt
+++ b/app/src/main/java/network/omisego/omgwallet/network/ClientProvider.kt
@@ -25,7 +25,7 @@ object ClientProvider {
     private lateinit var clientConfiguration: ClientConfiguration
     private lateinit var socketClientConfiguration: ClientConfiguration
     lateinit var client: OMGAPIClient
-    lateinit var socketClient: SocketClientContract.Client
+    var socketClient: SocketClientContract.Client? = null
     lateinit var eWalletClient: EWalletClient
     lateinit var clientSetup: ClientSetup
 
@@ -49,7 +49,7 @@ object ClientProvider {
     }
 
     fun addSocketListener() {
-        ClientProvider.socketClient.addChannelListener(object : SocketChannelListener {
+        ClientProvider.socketClient?.addChannelListener(object : SocketChannelListener {
             override fun onError(apiError: APIError): Boolean {
                 logi("Error: ${apiError.description}")
                 return true
@@ -66,7 +66,7 @@ object ClientProvider {
             }
         })
 
-        ClientProvider.socketClient.addConnectionListener(object : SocketConnectionListener {
+        ClientProvider.socketClient?.addConnectionListener(object : SocketConnectionListener {
             override fun onConnected() {
                 Log.i("Socket", "Connected")
             }

--- a/app/src/main/java/network/omisego/omgwallet/network/ClientProvider.kt
+++ b/app/src/main/java/network/omisego/omgwallet/network/ClientProvider.kt
@@ -1,12 +1,16 @@
 package network.omisego.omgwallet.network
 
+import android.util.Log
 import co.omisego.omisego.OMGAPIClient
+import co.omisego.omisego.model.APIError
 import co.omisego.omisego.model.ClientConfiguration
 import co.omisego.omisego.network.ewallet.EWalletClient
 import co.omisego.omisego.websocket.OMGSocketClient
 import co.omisego.omisego.websocket.SocketClientContract
+import co.omisego.omisego.websocket.listener.SocketChannelListener
+import co.omisego.omisego.websocket.listener.SocketConnectionListener
 import com.facebook.stetho.okhttp3.StethoInterceptor
-import network.omisego.omgwallet.model.Credential
+import network.omisego.omgwallet.extension.logi
 import network.omisego.omgwallet.storage.Storage
 import okhttp3.logging.HttpLoggingInterceptor
 
@@ -18,9 +22,6 @@ import okhttp3.logging.HttpLoggingInterceptor
  */
 
 object ClientProvider {
-    private val credential: Credential
-        get() = Storage.loadCredential()
-
     private lateinit var clientConfiguration: ClientConfiguration
     private lateinit var socketClientConfiguration: ClientConfiguration
     lateinit var client: OMGAPIClient
@@ -28,16 +29,52 @@ object ClientProvider {
     lateinit var eWalletClient: EWalletClient
     lateinit var clientSetup: ClientSetup
 
-    fun init(clientSetup: ClientSetup) {
+    fun initHTTPClient(clientSetup: ClientSetup) {
         this.clientSetup = clientSetup
         clientConfiguration = ClientConfiguration(
             clientSetup.baseURL,
             clientSetup.apiKey,
-            credential.authenticationToken
+            Storage.loadCredential().authenticationToken
         )
-        socketClientConfiguration = clientConfiguration.copy(baseURL = clientSetup.socketBaseURL)
         client = create()
+    }
+
+    fun initSocketClient(authenticationToken: String) {
+        socketClientConfiguration = clientConfiguration.copy(
+            baseURL = clientSetup.socketBaseURL,
+            authenticationToken = authenticationToken
+        )
         socketClient = createSocketClient()
+        addSocketListener()
+    }
+
+    fun addSocketListener() {
+        ClientProvider.socketClient.addChannelListener(object : SocketChannelListener {
+            override fun onError(apiError: APIError): Boolean {
+                logi("Error: ${apiError.description}")
+                return true
+            }
+
+            override fun onJoinedChannel(topic: String): Boolean {
+                Log.i("Socket", "Joined: ${topic}")
+                return true
+            }
+
+            override fun onLeftChannel(topic: String): Boolean {
+                Log.i("Socket", "Left $topic")
+                return true
+            }
+        })
+
+        ClientProvider.socketClient.addConnectionListener(object : SocketConnectionListener {
+            override fun onConnected() {
+                Log.i("Socket", "Connected")
+            }
+
+            override fun onDisconnected(throwable: Throwable?) {
+                Log.i("Socket", "Disconnected")
+            }
+        })
     }
 
     private fun create(): OMGAPIClient {

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/MainFragment.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/MainFragment.kt
@@ -13,10 +13,8 @@ import androidx.navigation.NavDestination
 import androidx.navigation.findNavController
 import androidx.navigation.ui.setupWithNavController
 import co.omisego.omisego.model.APIError
-import co.omisego.omisego.model.transaction.consumption.TransactionConsumption
-import co.omisego.omisego.model.transaction.consumption.TransactionConsumptionStatus.APPROVED
-import co.omisego.omisego.model.transaction.consumption.TransactionConsumptionStatus.CONFIRMED
-import co.omisego.omisego.model.transaction.consumption.TransactionConsumptionStatus.REJECTED
+import co.omisego.omisego.model.TransactionConsumption
+import co.omisego.omisego.model.TransactionConsumptionStatus
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_main.*
 import network.omisego.omgwallet.GraphMainDirections
@@ -66,8 +64,8 @@ class MainFragment : Fragment() {
     }
 
     override fun onStop() {
-        super.onStop()
         viewModel.stopListenForUserEvent()
+        super.onStop()
     }
 
     override fun onDestroyView() {
@@ -137,8 +135,8 @@ class MainFragment : Fragment() {
             /* Show notification */
             val message: String
             when (txConsumption.status) {
-                CONFIRMED,
-                APPROVED -> {
+                TransactionConsumptionStatus.CONFIRMED,
+                TransactionConsumptionStatus.APPROVED -> {
                     val amount = txConsumption.estimatedRequestAmount.divide(txConsumption.transactionRequest.token.subunitToUnit)
                     message = getString(
                         R.string.notification_transaction_received,
@@ -149,7 +147,7 @@ class MainFragment : Fragment() {
                     snackbar = bottomNavigation.snackbar(message)
                     snackbar.show()
                 }
-                REJECTED -> {
+                TransactionConsumptionStatus.REJECTED -> {
                     message = getString(
                         R.string.notification_transaction_rejected,
                         txConsumption.account?.name

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/MainFragment.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/MainFragment.kt
@@ -17,6 +17,7 @@ import co.omisego.omisego.model.TransactionConsumption
 import co.omisego.omisego.model.TransactionConsumptionStatus
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_main.*
+import network.omisego.omgwallet.GlobalViewModel
 import network.omisego.omgwallet.GraphMainDirections
 import network.omisego.omgwallet.MainActivity
 import network.omisego.omgwallet.R
@@ -32,6 +33,7 @@ class MainFragment : Fragment() {
     private lateinit var navController: NavController
     private lateinit var viewModel: MainViewModel
     private lateinit var balanceViewModel: BalanceViewModel
+    private lateinit var globalViewModel: GlobalViewModel
     private lateinit var snackbar: Snackbar
     private val hostActivity: MainActivity
         get() = (activity as MainActivity)
@@ -45,6 +47,7 @@ class MainFragment : Fragment() {
         super.onCreate(savedInstanceState)
         viewModel = provideActivityViewModel()
         balanceViewModel = provideActivityViewModel()
+        globalViewModel = provideActivityViewModel()
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
@@ -56,16 +59,10 @@ class MainFragment : Fragment() {
     override fun onStart() {
         super.onStart()
         showSplashIfNeeded()
-        viewModel.startListenForUserEvent()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_main, container, false)
-    }
-
-    override fun onStop() {
-        viewModel.stopListenForUserEvent()
-        super.onStop()
     }
 
     override fun onDestroyView() {
@@ -74,10 +71,10 @@ class MainFragment : Fragment() {
     }
 
     private fun listenForSocketEvent() {
-        viewModel.liveConsumptionRequestEvent.observe(this, ConsumptionRequestObserver())
-        viewModel.liveConsumptionRequestFailEvent.observe(this, ConsumptionRequestFailObserver())
-        viewModel.liveConsumptionFinalizedEvent.observe(this, ConsumptionFinalizedObserver())
-        viewModel.liveConsumptionFinalizedFailEvent.observe(this, ConsumptionFinalizedFailObserver())
+        globalViewModel.liveConsumptionRequestEvent.observe(this, ConsumptionRequestObserver())
+        globalViewModel.liveConsumptionRequestFailEvent.observe(this, ConsumptionRequestFailObserver())
+        globalViewModel.liveConsumptionFinalizedEvent.observe(this, ConsumptionFinalizedObserver())
+        globalViewModel.liveConsumptionFinalizedFailEvent.observe(this, ConsumptionFinalizedFailObserver())
     }
 
     private fun showSplashIfNeeded() {

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/MainViewModel.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/MainViewModel.kt
@@ -10,10 +10,11 @@ package network.omisego.omgwallet.screen.auth
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import co.omisego.omisego.model.APIError
-import co.omisego.omisego.model.transaction.consumption.TransactionConsumption
+import co.omisego.omisego.model.TransactionConsumption
 import network.omisego.omgwallet.GraphMainDirections
 import network.omisego.omgwallet.data.LocalRepository
 import network.omisego.omgwallet.data.RemoteRepository
+import network.omisego.omgwallet.extension.logi
 
 class MainViewModel(
     private val localRepository: LocalRepository,
@@ -37,6 +38,7 @@ class MainViewModel(
         .setPrimaryTokenId(loadPrimaryTokenId())
 
     fun startListenForUserEvent() {
+        logi("start listen for user event...")
         remoteRepository.listenUserSocketEvent(
             liveConsumptionRequestEvent,
             liveConsumptionRequestFailEvent,

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/MainViewModel.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/MainViewModel.kt
@@ -28,5 +28,4 @@ class MainViewModel(
     fun provideSplashDirection() = GraphMainDirections
         .actionGlobalSplash()
         .setPrimaryTokenId(loadPrimaryTokenId())
-
 }

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/MainViewModel.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/MainViewModel.kt
@@ -7,23 +7,15 @@ package network.omisego.omgwallet.screen.auth
  * Copyright © 2017-2018 OmiseGO. All rights reserved.
  */
 
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import co.omisego.omisego.model.APIError
-import co.omisego.omisego.model.TransactionConsumption
 import network.omisego.omgwallet.GraphMainDirections
 import network.omisego.omgwallet.data.LocalRepository
 import network.omisego.omgwallet.data.RemoteRepository
-import network.omisego.omgwallet.extension.logi
 
 class MainViewModel(
     private val localRepository: LocalRepository,
     private val remoteRepository: RemoteRepository
 ) : ViewModel() {
-    val liveConsumptionRequestEvent: MutableLiveData<TransactionConsumption> by lazy { MutableLiveData<TransactionConsumption>() }
-    val liveConsumptionRequestFailEvent: MutableLiveData<APIError> by lazy { MutableLiveData<APIError>() }
-    val liveConsumptionFinalizedEvent: MutableLiveData<TransactionConsumption> by lazy { MutableLiveData<TransactionConsumption>() }
-    val liveConsumptionFinalizedFailEvent: MutableLiveData<APIError> by lazy { MutableLiveData<APIError>() }
 
     fun hasTransactionRequestFormattedId(): Boolean {
         return localRepository.hasFormattedId()
@@ -37,17 +29,4 @@ class MainViewModel(
         .actionGlobalSplash()
         .setPrimaryTokenId(loadPrimaryTokenId())
 
-    fun startListenForUserEvent() {
-        logi("start listen for user event...")
-        remoteRepository.listenUserSocketEvent(
-            liveConsumptionRequestEvent,
-            liveConsumptionRequestFailEvent,
-            liveConsumptionFinalizedEvent,
-            liveConsumptionFinalizedFailEvent
-        )
-    }
-
-    fun stopListenForUserEvent() {
-        remoteRepository.stopListeningToUserSocketEvent()
-    }
 }

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/confirm/ConfirmTransactionRequestFragment.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/confirm/ConfirmTransactionRequestFragment.kt
@@ -14,7 +14,7 @@ import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import co.omisego.omisego.model.APIError
-import co.omisego.omisego.model.transaction.consumption.TransactionConsumption
+import co.omisego.omisego.model.TransactionConsumption
 import network.omisego.omgwallet.R
 import network.omisego.omgwallet.databinding.FragmentConfirmTransactionRequestBinding
 import network.omisego.omgwallet.extension.provideAndroidViewModel

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/confirm/ConfirmTransactionRequestViewModel.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/confirm/ConfirmTransactionRequestViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
 import co.omisego.omisego.constant.enums.ErrorCode
 import co.omisego.omisego.model.APIError
-import co.omisego.omisego.model.transaction.consumption.TransactionConsumption
+import co.omisego.omisego.model.TransactionConsumption
 import network.omisego.omgwallet.R
 import network.omisego.omgwallet.data.LocalRepository
 import network.omisego.omgwallet.data.RemoteRepository

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/profile/main/ProfileFragment.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/profile/main/ProfileFragment.kt
@@ -18,6 +18,7 @@ import kotlinx.android.synthetic.main.fragment_profile.*
 import network.omisego.omgwallet.R
 import network.omisego.omgwallet.databinding.FragmentProfileBinding
 import network.omisego.omgwallet.extension.bindingInflate
+import network.omisego.omgwallet.extension.findLoginListener
 import network.omisego.omgwallet.extension.findRootNavController
 import network.omisego.omgwallet.extension.provideAndroidViewModel
 import network.omisego.omgwallet.extension.toast
@@ -51,12 +52,14 @@ class ProfileFragment : Fragment() {
         })
 
         viewModel.liveSignout.observe(this, EventObserver {
-            it.let { _ ->
+            it.let {
                 /* Clear all back-stack fragments */
                 findRootNavController().popBackStack(R.id.authFragment, true)
 
                 /* Go back to sign-in */
                 findRootNavController().navigate(R.id.action_global_signInFragment)
+
+                findLoginListener()?.onLoggedout()
             }
         })
 

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/profile/main/ProfileViewModel.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/profile/main/ProfileViewModel.kt
@@ -13,15 +13,13 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
 import co.infinum.goldfinger.Goldfinger
 import network.omisego.omgwallet.data.LocalRepository
-import network.omisego.omgwallet.data.RemoteRepository
 import network.omisego.omgwallet.livedata.Event
 import network.omisego.omgwallet.network.ClientProvider
 import network.omisego.omgwallet.state.FingerprintDialogState
 
 class ProfileViewModel(
     private val app: Application,
-    private val localRepository: LocalRepository,
-    private val remoteRepository: RemoteRepository
+    private val localRepository: LocalRepository
 ) : AndroidViewModel(app) {
     val liveFingerprintDialogState: MutableLiveData<FingerprintDialogState> by lazy { MutableLiveData<FingerprintDialogState>() }
     val liveTransaction: MutableLiveData<Event<View>> by lazy { MutableLiveData<Event<View>>() }
@@ -30,8 +28,6 @@ class ProfileViewModel(
     val liveEndpoint: MutableLiveData<String> by lazy { MutableLiveData<String>() }
 
     fun clickSignout(view: View) {
-        localRepository.clearSession()
-        remoteRepository.stopListeningToUserSocketEvent()
         liveSignout.value = Event(view)
     }
 

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/profile/transaction/TransactionListFragment.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/profile/transaction/TransactionListFragment.kt
@@ -11,8 +11,8 @@ import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import co.omisego.omisego.model.APIError
+import co.omisego.omisego.model.Transaction
 import co.omisego.omisego.model.pagination.PaginationList
-import co.omisego.omisego.model.transaction.Transaction
 import kotlinx.android.synthetic.main.fragment_transaction_list.*
 import network.omisego.omgwallet.R
 import network.omisego.omgwallet.base.LoadingRecyclerAdapter

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/profile/transaction/TransactionListTransformer.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/profile/transaction/TransactionListTransformer.kt
@@ -8,9 +8,9 @@ package network.omisego.omgwallet.screen.auth.profile.transaction
  */
 
 import android.content.Context
+import co.omisego.omisego.model.Transaction
+import co.omisego.omisego.model.TransactionSource
 import co.omisego.omisego.model.pagination.Paginable
-import co.omisego.omisego.model.transaction.Transaction
-import co.omisego.omisego.model.transaction.TransactionSource
 import network.omisego.omgwallet.R
 
 class TransactionListTransformer(
@@ -33,12 +33,12 @@ class TransactionListTransformer(
         return if (transaction.isTopup) {
             context.getString(
                 R.string.transaction_list_info_name_id,
-                transaction.from.username
+                transaction.from.user?.email
             )
         } else {
             context.getString(
                 R.string.transaction_list_info_name_id,
-                transaction.to.username
+                transaction.to.user?.email
             )
         }
     }

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/profile/transaction/TransactionListViewModel.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/profile/transaction/TransactionListViewModel.kt
@@ -11,9 +11,9 @@ import android.app.Application
 import android.os.Bundle
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
+import co.omisego.omisego.model.Transaction
 import co.omisego.omisego.model.Wallet
-import co.omisego.omisego.model.transaction.Transaction
-import co.omisego.omisego.model.transaction.list.TransactionListParams
+import co.omisego.omisego.model.params.TransactionListParams
 import network.omisego.omgwallet.R
 import network.omisego.omgwallet.base.StateViewHolderBinding
 import network.omisego.omgwallet.data.LocalRepository

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/splash/PreloadResourceViewModel.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/splash/PreloadResourceViewModel.kt
@@ -14,11 +14,9 @@ import androidx.lifecycle.MutableLiveData
 import co.omisego.omisego.model.APIError
 import co.omisego.omisego.model.Balance
 import co.omisego.omisego.model.Token
+import co.omisego.omisego.model.TransactionRequestType
 import co.omisego.omisego.model.WalletList
-import co.omisego.omisego.model.transaction.request.TransactionRequestCreateParams
-import co.omisego.omisego.model.transaction.request.TransactionRequestType
-import co.omisego.omisego.model.transaction.request.TransactionRequestType.RECEIVE
-import co.omisego.omisego.model.transaction.request.TransactionRequestType.SEND
+import co.omisego.omisego.model.params.client.TransactionRequestCreateParams
 import kotlinx.coroutines.experimental.android.UI
 import kotlinx.coroutines.experimental.async
 import kotlinx.coroutines.experimental.launch
@@ -83,16 +81,16 @@ class PreloadResourceViewModel(
             val result = async {
                 val txReceiveResult = remoteRepository.createTransactionRequest(params)
                 val txSendResult = remoteRepository.createTransactionRequest(
-                    params.copy(type = SEND, requireConfirmation = true)
+                    params.copy(type = TransactionRequestType.SEND, requireConfirmation = true)
                 )
                 return@async txReceiveResult to txSendResult
             }
             val (txReceive, txSend) = result.await()
-            txReceive.either({ formattedIds[RECEIVE] = it.data.formattedId }, this@PreloadResourceViewModel::handleAPIError)
-            txSend.either({ formattedIds[SEND] = it.data.formattedId }, this@PreloadResourceViewModel::handleAPIError)
+            txReceive.either({ formattedIds[TransactionRequestType.RECEIVE] = it.data.formattedId }, this@PreloadResourceViewModel::handleAPIError)
+            txSend.either({ formattedIds[TransactionRequestType.SEND] = it.data.formattedId }, this@PreloadResourceViewModel::handleAPIError)
 
             if (formattedIds.size == 2) {
-                val message = "${formattedIds[RECEIVE]}|${formattedIds[SEND]}"
+                val message = "${formattedIds[TransactionRequestType.RECEIVE]}|${formattedIds[TransactionRequestType.SEND]}"
                 logi(message)
 
                 localRepository.saveTransactionRequestFormattedId(formattedIds)
@@ -118,7 +116,7 @@ class PreloadResourceViewModel(
 
     fun createTransactionRequestCreateParams(token: Token): TransactionRequestCreateParams {
         return TransactionRequestCreateParams(
-            RECEIVE,
+            TransactionRequestType.RECEIVE,
             token.id,
             requireConfirmation = false
         )

--- a/app/src/main/java/network/omisego/omgwallet/screen/unauth/SignInFragment.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/unauth/SignInFragment.kt
@@ -28,6 +28,7 @@ import kotlinx.android.synthetic.main.fragment_signin.*
 import network.omisego.omgwallet.R
 import network.omisego.omgwallet.databinding.FragmentSigninBinding
 import network.omisego.omgwallet.extension.bindingInflate
+import network.omisego.omgwallet.extension.findLoginListener
 import network.omisego.omgwallet.extension.provideAndroidViewModel
 import network.omisego.omgwallet.extension.runOnM
 import network.omisego.omgwallet.extension.runOnMToP
@@ -140,8 +141,7 @@ class SignInFragment : Fragment() {
     }
 
     private fun proceed(data: ClientAuthenticationToken) {
-        viewModel.saveCredential(data)
-        viewModel.saveUserEmail(etEmail.text.toString())
+        findLoginListener()?.onLoggedin(etEmail.text.toString(), data)
         findNavController().navigate(R.id.action_signInFragment_to_authFragment)
     }
 

--- a/app/src/main/java/network/omisego/omgwallet/screen/unauth/signin/SignInViewModel.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/unauth/signin/SignInViewModel.kt
@@ -17,7 +17,6 @@ import android.view.View
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import co.omisego.omisego.model.ClientAuthenticationToken
 import co.omisego.omisego.model.params.LoginParams
 import network.omisego.omgwallet.BuildConfig
 import network.omisego.omgwallet.R
@@ -32,7 +31,6 @@ import network.omisego.omgwallet.extension.runOnP
 import network.omisego.omgwallet.livedata.Event
 import network.omisego.omgwallet.livedata.SingleLiveEvent
 import network.omisego.omgwallet.model.APIResult
-import network.omisego.omgwallet.model.Credential
 import network.omisego.omgwallet.util.BiometricUtil
 import network.omisego.omgwallet.util.ContextUtil.context
 import network.omisego.omgwallet.util.click
@@ -147,20 +145,6 @@ class SignInViewModel(
         arrayOf(emailValidator, passwordValidator).find { !it.validation.pass }?.let { return null }
         showLoading(app.getString(R.string.sign_in_button_loading))
         return remoteRepository.signIn(LoginParams(email, password), liveAPIResult)
-    }
-
-    fun saveCredential(data: ClientAuthenticationToken) {
-        localRepository.saveUser(data.user)
-        localRepository.saveCredential(
-            Credential(
-                data.authenticationToken
-            )
-        )
-    }
-
-    fun saveUserEmail(email: String) {
-        localRepository.clearOldAccountCache(email)
-        localRepository.saveUserEmail(email)
     }
 
     fun showLoading(text: String) {

--- a/app/src/main/java/network/omisego/omgwallet/storage/Storage.kt
+++ b/app/src/main/java/network/omisego/omgwallet/storage/Storage.kt
@@ -10,9 +10,9 @@ package network.omisego.omgwallet.storage
 import android.content.Context
 import android.content.SharedPreferences
 import co.omisego.omisego.model.Token
+import co.omisego.omisego.model.TransactionRequestType
 import co.omisego.omisego.model.User
 import co.omisego.omisego.model.WalletList
-import co.omisego.omisego.model.transaction.request.TransactionRequestType
 import co.omisego.omisego.security.OMGKeyManager
 import co.omisego.omisego.utils.GsonProvider
 import kotlinx.coroutines.experimental.Deferred

--- a/app/src/main/java/network/omisego/omgwallet/util/RepositoryUtil.kt
+++ b/app/src/main/java/network/omisego/omgwallet/util/RepositoryUtil.kt
@@ -1,0 +1,16 @@
+package network.omisego.omgwallet.util
+
+/*
+ * OmiseGO
+ *
+ * Created by Phuchit Sirimongkolsathien on 23/11/2018 AD.
+ * Copyright © 2017-2018 OmiseGO. All rights reserved.
+ */
+
+import network.omisego.omgwallet.data.LocalRepository
+import network.omisego.omgwallet.data.RemoteRepository
+
+object RepositoryUtil {
+    lateinit var localRepository: LocalRepository
+    lateinit var remoteRepository: RemoteRepository
+}

--- a/app/src/main/res/layout/fragment_confirm_transaction_request.xml
+++ b/app/src/main/res/layout/fragment_confirm_transaction_request.xml
@@ -11,7 +11,7 @@
 
         <variable
             name="txConsumption"
-            type="co.omisego.omisego.model.transaction.consumption.TransactionConsumption" />
+            type="co.omisego.omisego.model.TransactionConsumption" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/viewholder_transaction.xml
+++ b/app/src/main/res/layout/viewholder_transaction.xml
@@ -15,7 +15,7 @@
 
         <variable
             name="transaction"
-            type="co.omisego.omisego.model.transaction.Transaction" />
+            type="co.omisego.omisego.model.Transaction" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/navigation/graph_main.xml
+++ b/app/src/main/res/navigation/graph_main.xml
@@ -76,7 +76,7 @@
         tools:layout="@layout/fragment_confirm_transaction_request">
         <argument
             android:name="transactionConsumption"
-            app:argType="co.omisego.omisego.model.transaction.consumption.TransactionConsumption" />
+            app:argType="co.omisego.omisego.model.TransactionConsumption" />
     </fragment>
     <action
         android:id="@+id/action_global_confirmTransactionRequest"


### PR DESCRIPTION
Issue/Task Number: #24 

Closes #24 

# Overview

This PR fixes the issue that the app cannot receive the socket event when login successfully. The cause is the socket client was initialized before login and it was not re-initialized after user logged in. The web socket will then receive `403 Forbidden` because the `authentication token` is null.

The solution this PR introduces is about to make sure that the web socket is initialized after logged in and then subscribe to the user event respectively.
