### PR TITLE
Improve display amount format to prevent loss precision

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with NO BOM" />
+</project>

--- a/app/src/androidTest/java/network/omisego/omgwallet/BalanceDetailTest.kt
+++ b/app/src/androidTest/java/network/omisego/omgwallet/BalanceDetailTest.kt
@@ -1,9 +1,9 @@
 package network.omisego.omgwallet
 
 import androidx.test.runner.AndroidJUnit4
+import co.omisego.omisego.model.TransactionRequestType
 import co.omisego.omisego.model.params.LoginParams
-import co.omisego.omisego.model.transaction.request.TransactionRequestParams
-import co.omisego.omisego.model.transaction.request.TransactionRequestType
+import co.omisego.omisego.model.params.TransactionRequestParams
 import com.agoda.kakao.KButton
 import network.omisego.omgwallet.base.BaseInstrumentalTest
 import network.omisego.omgwallet.config.LocalClientSetup

--- a/app/src/androidTest/java/network/omisego/omgwallet/ConsumeTransactionRequestTest.kt
+++ b/app/src/androidTest/java/network/omisego/omgwallet/ConsumeTransactionRequestTest.kt
@@ -4,8 +4,8 @@ import androidx.test.runner.AndroidJUnit4
 import co.omisego.omisego.extension.bd
 import co.omisego.omisego.model.Balance
 import co.omisego.omisego.model.Token
+import co.omisego.omisego.model.TransactionConsumption
 import co.omisego.omisego.model.params.LoginParams
-import co.omisego.omisego.model.transaction.consumption.TransactionConsumption
 import com.agoda.kakao.KView
 import network.omisego.omgwallet.base.BaseInstrumentalTest
 import network.omisego.omgwallet.config.LocalClientSetup

--- a/app/src/androidTest/java/network/omisego/omgwallet/config/TxConsumerClient.kt
+++ b/app/src/androidTest/java/network/omisego/omgwallet/config/TxConsumerClient.kt
@@ -4,10 +4,10 @@ import co.omisego.omisego.OMGAPIClient
 import co.omisego.omisego.extension.bd
 import co.omisego.omisego.model.ClientAuthenticationToken
 import co.omisego.omisego.model.ClientConfiguration
+import co.omisego.omisego.model.TransactionConsumption
 import co.omisego.omisego.model.params.LoginParams
-import co.omisego.omisego.model.transaction.consumption.TransactionConsumption
-import co.omisego.omisego.model.transaction.consumption.TransactionConsumptionParams
-import co.omisego.omisego.model.transaction.request.TransactionRequestParams
+import co.omisego.omisego.model.params.TransactionRequestParams
+import co.omisego.omisego.model.params.client.TransactionConsumptionParams
 import co.omisego.omisego.network.ewallet.EWalletClient
 import okhttp3.OkHttpClient
 import java.math.BigDecimal

--- a/app/src/main/java/network/omisego/omgwallet/extension/BalanceExt.kt
+++ b/app/src/main/java/network/omisego/omgwallet/extension/BalanceExt.kt
@@ -1,0 +1,50 @@
+package network.omisego.omgwallet.extension
+
+/*
+ * OmiseGO
+ *
+ * Created by Phuchit Sirimongkolsathien on 6/12/2018 AD.
+ * Copyright © 2017-2018 OmiseGO. All rights reserved.
+ */
+
+import co.omisego.omisego.model.Balance
+import co.omisego.omisego.model.TransactionConsumption
+import co.omisego.omisego.model.TransactionSource
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+fun Balance.displayFormattedAmount(maxPrecision: Int = token.subunitToUnit.precision() - 1, minPrecision: Int = 2): BigDecimal {
+    val value = amount
+        .divide(token.subunitToUnit, maxPrecision, RoundingMode.HALF_UP)
+        .stripTrailingZeros()
+
+    if (value.scale() < minPrecision) {
+        // upscale
+        return value.setScale(minPrecision)
+    }
+    return value
+}
+
+fun TransactionSource.displayFormattedAmount(maxPrecision: Int = token.subunitToUnit.precision() - 1, minPrecision: Int = 2): BigDecimal {
+    val value = amount
+        .divide(token.subunitToUnit, maxPrecision, RoundingMode.HALF_UP)
+        .stripTrailingZeros()
+
+    if (value.scale() < minPrecision) {
+        // upscale
+        return value.setScale(minPrecision)
+    }
+    return value
+}
+
+fun TransactionConsumption.displayFormattedAmount(maxPrecision: Int = transactionRequest.token.subunitToUnit.precision() - 1, minPrecision: Int = 2): BigDecimal {
+    val value = estimatedRequestAmount
+        .divide(transactionRequest.token.subunitToUnit, maxPrecision, RoundingMode.HALF_UP)
+        .stripTrailingZeros()
+
+    if (value.scale() < minPrecision) {
+        // upscale
+        return value.setScale(minPrecision)
+    }
+    return value
+}

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/MainFragment.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/MainFragment.kt
@@ -21,6 +21,7 @@ import network.omisego.omgwallet.GlobalViewModel
 import network.omisego.omgwallet.GraphMainDirections
 import network.omisego.omgwallet.MainActivity
 import network.omisego.omgwallet.R
+import network.omisego.omgwallet.extension.displayFormattedAmount
 import network.omisego.omgwallet.extension.getColor
 import network.omisego.omgwallet.extension.logi
 import network.omisego.omgwallet.extension.provideActivityViewModel
@@ -139,10 +140,9 @@ class MainFragment : Fragment() {
                     } else {
                         R.string.notification_transaction_approved_received
                     }
-                    val amount = txConsumption.estimatedRequestAmount.divide(txConsumption.transactionRequest.token.subunitToUnit)
                     message = getString(
                         templateRes,
-                        amount,
+                        txConsumption.displayFormattedAmount(),
                         txConsumption.transactionRequest.token.symbol,
                         txConsumption.account?.name
                     )

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/balance/BalanceFragment.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/balance/BalanceFragment.kt
@@ -1,5 +1,12 @@
 package network.omisego.omgwallet.screen.auth.balance
 
+/*
+ * OmiseGO
+ *
+ * Created by Phuchit Sirimongkolsathien on 21/9/2018 AD.
+ * Copyright © 2017-2018 OmiseGO. All rights reserved.
+ */
+
 import android.graphics.Rect
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -30,13 +37,6 @@ import network.omisego.omgwallet.extension.provideActivityViewModel
 import network.omisego.omgwallet.extension.toast
 import network.omisego.omgwallet.livedata.EventObserver
 import network.omisego.omgwallet.storage.Storage
-
-/*
- * OmiseGO
- *
- * Created by Phuchit Sirimongkolsathien on 21/9/2018 AD.
- * Copyright © 2017-2018 OmiseGO. All rights reserved.
- */
 
 class BalanceFragment : Fragment(), UpdateAdapterDispatcher<Balance> {
     private var currentBalances: List<Balance> = listOf()

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/balance/BalanceViewModel.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/balance/BalanceViewModel.kt
@@ -16,6 +16,7 @@ import network.omisego.omgwallet.base.StateViewHolderBinding
 import network.omisego.omgwallet.data.LocalRepository
 import network.omisego.omgwallet.data.contract.BalanceDataRepository
 import network.omisego.omgwallet.databinding.ViewholderBalanceBinding
+import network.omisego.omgwallet.extension.displayFormattedAmount
 import network.omisego.omgwallet.livedata.Event
 import network.omisego.omgwallet.model.APIResult
 import network.omisego.omgwallet.storage.Storage
@@ -34,7 +35,7 @@ class BalanceViewModel(
     override fun bind(binding: ViewholderBalanceBinding, data: Balance) {
         binding.balance = data
         binding.viewModel = this
-        binding.tvAmount.text = data.displayAmount(2)
+        binding.tvAmount.text = data.displayFormattedAmount(2).toString()
     }
 
     val liveResult: MutableLiveData<Event<APIResult>> by lazy { MutableLiveData<Event<APIResult>>() }

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/balance/detail/BalanceDetailItemViewModel.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/balance/detail/BalanceDetailItemViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
 import co.omisego.omisego.model.Balance
 import network.omisego.omgwallet.R
+import network.omisego.omgwallet.extension.displayFormattedAmount
 
 class BalanceDetailItemViewModel(
     val app: Application
@@ -20,7 +21,7 @@ class BalanceDetailItemViewModel(
     val liveTokenPrimaryText: MutableLiveData<String> by lazy { MutableLiveData<String>() }
     val liveTokenPrimaryEnabled: MutableLiveData<Boolean> by lazy { MutableLiveData<Boolean>() }
 
-    fun displayAmount(balance: Balance) = balance.displayAmount()
+    fun displayAmount(balance: Balance) = balance.displayFormattedAmount().toString()
     fun displayDate(balance: Balance) = app.getString(R.string.balance_detail_last_updated, balance.token.updatedAt)
     fun resolveTokenPrimaryText(balance: Balance, tokenPrimaryId: String?) {
         liveTokenPrimaryText.value = if (tokenPrimaryId == balance.token.id) {

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/confirm/ConfirmTransactionRequestViewModel.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/confirm/ConfirmTransactionRequestViewModel.kt
@@ -9,6 +9,7 @@ import co.omisego.omisego.model.TransactionConsumption
 import network.omisego.omgwallet.R
 import network.omisego.omgwallet.data.LocalRepository
 import network.omisego.omgwallet.data.RemoteRepository
+import network.omisego.omgwallet.extension.displayFormattedAmount
 import network.omisego.omgwallet.livedata.Event
 import network.omisego.omgwallet.model.APIResult
 
@@ -33,7 +34,7 @@ class ConfirmTransactionRequestViewModel(
     fun formatAmount(txConsumption: TransactionConsumption) {
         liveAmountText.value = app.getString(
             R.string.confirm_transaction_request_amount,
-            txConsumption.estimatedRequestAmount.divide(txConsumption.transactionRequest.token.subunitToUnit),
+            txConsumption.displayFormattedAmount(),
             txConsumption.transactionRequest.token.symbol
         )
     }

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/profile/transaction/TransactionListTransformer.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/profile/transaction/TransactionListTransformer.kt
@@ -9,36 +9,26 @@ package network.omisego.omgwallet.screen.auth.profile.transaction
 
 import android.content.Context
 import co.omisego.omisego.model.Transaction
-import co.omisego.omisego.model.TransactionSource
 import co.omisego.omisego.model.pagination.Paginable
 import network.omisego.omgwallet.R
+import network.omisego.omgwallet.extension.displayFormattedAmount
 
 class TransactionListTransformer(
     val context: Context
 ) {
-    val TransactionSource.username: String
-        get() = "${this.account?.name ?: this.account?.name}"
     val Transaction.isTopup: Boolean
         get() = this.from.accountId != null
-
-    fun transformTransactionType(transaction: Transaction): String {
-        return if (transaction.isTopup) {
-            "\uE92F"
-        } else {
-            "\uE902"
-        }
-    }
 
     fun transformTransactionDisplayName(transaction: Transaction): String {
         return if (transaction.isTopup) {
             context.getString(
                 R.string.transaction_list_info_name_id,
-                transaction.from.user?.email
+                transaction.from.account?.name
             )
         } else {
             context.getString(
                 R.string.transaction_list_info_name_id,
-                transaction.to.user?.email
+                transaction.to.account?.name
             )
         }
     }
@@ -55,13 +45,13 @@ class TransactionListTransformer(
         val amountText = if (transaction.isTopup) {
             context.getString(
                 R.string.transaction_list_info_amount,
-                transaction.to.amount.divide(transaction.to.token.subunitToUnit),
+                transaction.to.displayFormattedAmount(maxPrecision = 2),
                 transaction.to.token.symbol
             )
         } else {
             context.getString(
                 R.string.transaction_list_info_amount,
-                transaction.from.amount.divide(transaction.from.token.subunitToUnit),
+                transaction.from.displayFormattedAmount(maxPrecision = 2),
                 transaction.from.token.symbol
             )
         }

--- a/app/src/main/java/network/omisego/omgwallet/screen/auth/profile/transaction/TransactionListViewModel.kt
+++ b/app/src/main/java/network/omisego/omgwallet/screen/auth/profile/transaction/TransactionListViewModel.kt
@@ -19,6 +19,7 @@ import network.omisego.omgwallet.base.StateViewHolderBinding
 import network.omisego.omgwallet.data.LocalRepository
 import network.omisego.omgwallet.data.RemoteRepository
 import network.omisego.omgwallet.databinding.ViewholderTransactionBinding
+import network.omisego.omgwallet.extension.displayFormattedAmount
 import network.omisego.omgwallet.extension.mutableLiveDataOf
 import network.omisego.omgwallet.model.APIResult
 
@@ -54,14 +55,14 @@ class TransactionListViewModel(
             liveTransactionFailedDescription.value = if (transaction.isTopup) {
                 app.getString(
                     R.string.transaction_list_topup_info,
-                    transaction.to.amount.divide(transaction.to.token.subunitToUnit),
+                    transaction.to.displayFormattedAmount(),
                     transaction.to.token.symbol,
                     transaction.from.account?.name
                 )
             } else {
                 app.getString(
                     R.string.transaction_list_pay_info,
-                    transaction.from.amount.divide(transaction.from.token.subunitToUnit),
+                    transaction.from.displayFormattedAmount(),
                     transaction.from.token.symbol,
                     transaction.to.account?.name
                 )

--- a/app/src/main/res/layout/viewholder_balance_detail.xml
+++ b/app/src/main/res/layout/viewholder_balance_detail.xml
@@ -101,7 +101,7 @@
                         android:text="@{viewModel.displayAmount(balance)}"
                         android:textColor="@color/colorBlackWeak"
                         android:textSize="34sp"
-                        tools:text="20,000" />
+                        tools:text="2.00005" />
 
                     <TextView
                         android:id="@+id/tvSymbol"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,7 +57,7 @@
     <string name="transaction_list_info_success">Success</string>
     <string name="transaction_list_info_failure">Failure</string>
     <string name="transaction_list_topup_info">Receive top-up %,.2f %s from %s</string>
-    <string name="transaction_list_pay_info">Pay %,.2f %s to %s</string>
+    <string name="transaction_list_pay_info">Pay %s %s to %s</string>
     <string name="transaction_list_empty_transaction">EMPTY TRANSACTION</string>
 
     <!-- Show QR -->
@@ -96,15 +96,15 @@
     <!-- Confirm Transaction Request-->
     <string name="confirm_transaction_request_title">Confirm Transaction Request</string>
     <string name="confirm_transaction_request_send">Send</string>
-    <string name="confirm_transaction_request_amount">%,.2f %s</string>
+    <string name="confirm_transaction_request_amount">%s %s</string>
     <string name="confirm_transaction_request_to">To %s</string>
     <string name="confirm_transaction_request_approve">Approve</string>
     <string name="confirm_transaction_request_reject">Reject</string>
     <string name="confirm_transaction_request_error_not_has_enough_fund">Your current account does not have enough fund (%s %s)</string>
 
     <!-- Transaction Notification Message -->
-    <string name="notification_transaction_approved_received">Successfully received %,.2f %s from %s</string>
-    <string name="notification_transaction_approved_sent">Successfully sent %,.2f %s to %s</string>
+    <string name="notification_transaction_approved_received">Successfully received %s %s from %s</string>
+    <string name="notification_transaction_approved_sent">Successfully sent %s %s to %s</string>
     <string name="notification_transaction_rejected">Transaction request from %s has been rejected</string>
 
     <!-- Fingerprint -->

--- a/app/src/test/kotlin/network/omisego/omgwallet/AmountDisplayTest.kt
+++ b/app/src/test/kotlin/network/omisego/omgwallet/AmountDisplayTest.kt
@@ -26,7 +26,7 @@ class AmountDisplayTest {
     }
 
     @Test
-    fun `test amount should not be loss precision to display`() {
+    fun `test amount should not loss precision`() {
         whenever(mockBalance.amount).thenReturn(1240.bd)
         whenever(mockBalance.token.subunitToUnit).thenReturn(100.bd)
 

--- a/app/src/test/kotlin/network/omisego/omgwallet/AmountDisplayTest.kt
+++ b/app/src/test/kotlin/network/omisego/omgwallet/AmountDisplayTest.kt
@@ -1,0 +1,65 @@
+package network.omisego.omgwallet
+
+/*
+ * OmiseGO
+ *
+ * Created by Phuchit Sirimongkolsathien on 6/12/2018 AD.
+ * Copyright © 2017-2018 OmiseGO. All rights reserved.
+ */
+
+import co.omisego.omisego.extension.bd
+import co.omisego.omisego.model.Balance
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+import network.omisego.omgwallet.extension.displayFormattedAmount
+import org.amshove.kluent.shouldEqual
+import org.junit.Before
+import org.junit.Test
+
+class AmountDisplayTest {
+
+    private val mockBalance: Balance = mock()
+
+    @Before
+    fun setup() {
+        whenever(mockBalance.token).thenReturn(mock())
+    }
+
+    @Test
+    fun `test amount should not be loss precision to display`() {
+        whenever(mockBalance.amount).thenReturn(1240.bd)
+        whenever(mockBalance.token.subunitToUnit).thenReturn(100.bd)
+
+        mockBalance.displayFormattedAmount() shouldEqual 12.40.bd.setScale(2)
+
+        whenever(mockBalance.amount).thenReturn(1245.bd)
+        whenever(mockBalance.token.subunitToUnit).thenReturn(100.bd)
+
+        mockBalance.displayFormattedAmount() shouldEqual 12.45.bd
+
+        whenever(mockBalance.amount).thenReturn(12.bd)
+        whenever(mockBalance.token.subunitToUnit).thenReturn(100.bd)
+
+        mockBalance.displayFormattedAmount() shouldEqual 0.12.bd
+
+        whenever(mockBalance.amount).thenReturn(1.bd)
+        whenever(mockBalance.token.subunitToUnit).thenReturn(100.bd)
+
+        mockBalance.displayFormattedAmount() shouldEqual 0.01.bd
+
+        whenever(mockBalance.amount).thenReturn(100.bd)
+        whenever(mockBalance.token.subunitToUnit).thenReturn(100.bd)
+
+        mockBalance.displayFormattedAmount() shouldEqual 1.00.bd.setScale(2)
+
+        whenever(mockBalance.amount).thenReturn(0.bd)
+        whenever(mockBalance.token.subunitToUnit).thenReturn(100000.bd)
+
+        mockBalance.displayFormattedAmount() shouldEqual 0.00.bd.setScale(2)
+
+        whenever(mockBalance.amount).thenReturn(200005000000000000.bd)
+        whenever(mockBalance.token.subunitToUnit).thenReturn(100000000000000000.bd)
+
+        mockBalance.displayFormattedAmount() shouldEqual 2.00005.bd
+    }
+}

--- a/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Issue/Task Number: #28 

Closes #28 

# Overview

This PR fixes the bug that the amount is not displayed correctly due to fixed precision in balance detail page.

Here is the improvement.

![screenshot_1544097084](https://user-images.githubusercontent.com/4509570/49582549-033d0800-f988-11e8-9fb3-ed552cde6ba9.png)

(For the same token amount in the current version is displayed "10.54")
